### PR TITLE
docs: align setup docs with current npm-based frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,15 @@
 
 | Task | Command |
 |------|---------|
-| Install deps | `make install` (or `npm install && cd frontend && pnpm install`) |
+| Install deps | `make install` (or `npm install && cd frontend && npm install`) |
 | Start dev | `make sandbox` (terminal 1) + `make dev` (terminal 2) |
 | Build | `make build` (frontend only) |
-| Type check | `make typecheck` |
+| Type check | `make typecheck` (frontend) |
 | Deploy | `make deploy` |
 | Run tests | `npx ts-node tests/integration/api-test.ts` |
 | Seed data | Open browser console → `window.seedService.reseedAll()` |
 
-**Tech Stack:** React 18 + TypeScript, Vite, Tailwind CSS, shadcn/ui, AWS Amplify Gen2, DynamoDB
+**Tech Stack:** React 18 + TypeScript, Vite, Tailwind CSS, shadcn/ui, AWS Amplify Gen2, DynamoDB (Supabase client foundation in frontend)
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Habits RPG Makefile
 # 頻繁に使用するコマンドをまとめたMakefile
 
-.PHONY: help install dev sandbox deploy lint format clean seed logs
+.PHONY: help install install-backend install-frontend dev sandbox sandbox-bg sandbox-delete deploy typecheck build seed db-tables logs aws-check clean supabase-start supabase-stop supabase-reset
 
 # デフォルトターゲット
 .DEFAULT_GOAL := help
@@ -25,14 +25,16 @@ help:
 	@echo "  make dev            - フロントエンド開発サーバーを起動"
 	@echo "  make sandbox        - バックエンドSandboxを起動"
 	@echo "  make sandbox-delete - Sandboxを削除"
+	@echo "  make supabase-start  - (任意) Supabaseローカル環境を起動"
+	@echo "  make supabase-stop   - (任意) Supabaseローカル環境を停止"
+	@echo "  make supabase-reset  - (任意) SupabaseローカルDBをリセット"
 	@echo ""
 	@echo "$(GREEN)デプロイ:$(RESET)"
 	@echo "  make deploy         - 本番環境にデプロイ"
 	@echo ""
 	@echo "$(GREEN)コード品質:$(RESET)"
-	@echo "  make lint           - Lintを実行"
-	@echo "  make format         - コードをフォーマット"
-	@echo "  make typecheck      - TypeScript型チェック"
+	@echo "  make typecheck      - TypeScript型チェック (frontend)"
+	@echo "  make build          - フロントエンドをビルド"
 	@echo ""
 	@echo "$(GREEN)データ管理:$(RESET)"
 	@echo "  make seed           - シードデータ投入の案内を表示"
@@ -55,13 +57,13 @@ install-backend:
 ## install-frontend: フロントエンド依存関係をインストール
 install-frontend:
 	@echo "$(CYAN)フロントエンド依存関係をインストール中...$(RESET)"
-	cd frontend && pnpm install
+	cd frontend && npm install
 
 ## dev: フロントエンド開発サーバーを起動
 dev:
 	@echo "$(CYAN)フロントエンド開発サーバーを起動します...$(RESET)"
-	@echo "$(YELLOW)URL: http://localhost:3001$(RESET)"
-	cd frontend && pnpm run dev
+	@echo "$(YELLOW)URL: http://localhost:3000$(RESET)"
+	cd frontend && npm run dev
 
 ## sandbox: バックエンドSandboxを起動
 sandbox:
@@ -86,27 +88,17 @@ deploy:
 	@echo "$(CYAN)本番環境にデプロイします...$(RESET)"
 	npx ampx pipeline-deploy --branch main
 
-## lint: Lintを実行
-lint:
-	@echo "$(CYAN)Lintを実行中...$(RESET)"
-	cd frontend && pnpm run lint
-
-## format: コードをフォーマット
-format:
-	@echo "$(CYAN)コードをフォーマット中...$(RESET)"
-	cd frontend && pnpm run format 2>/dev/null || npx prettier --write "src/**/*.{ts,tsx}"
-
-## typecheck: TypeScript型チェック
+## typecheck: TypeScript型チェック (frontend)
 typecheck:
 	@echo "$(CYAN)TypeScript型チェックを実行中...$(RESET)"
-	cd frontend && pnpm run typecheck 2>/dev/null || npx tsc --noEmit
+	cd frontend && npx tsc --noEmit
 
 ## seed: シードデータ投入の案内を表示
 seed:
 	@echo "$(CYAN)シードデータを投入するには:$(RESET)"
 	@echo ""
 	@echo "1. フロントエンド開発サーバーを起動: make dev"
-	@echo "2. ブラウザでアプリを開く: http://localhost:3001"
+	@echo "2. ブラウザでアプリを開く: http://localhost:3000"
 	@echo "3. ブラウザの開発者コンソールで以下を実行:"
 	@echo ""
 	@echo "   $(GREEN)window.seedService.reseedAll()$(RESET)"
@@ -144,10 +136,25 @@ aws-check:
 ## build: フロントエンドをビルド
 build:
 	@echo "$(CYAN)フロントエンドをビルド中...$(RESET)"
-	cd frontend && pnpm run build
+	cd frontend && npm run build
 
 ## start-all: SandboxとフロントエンドをBG起動
 start-all: sandbox-bg
 	@sleep 5
 	@echo "$(CYAN)フロントエンドを起動します...$(RESET)"
-	cd frontend && pnpm run dev
+	cd frontend && npm run dev
+
+## supabase-start: (任意) Supabaseローカル環境を起動
+supabase-start:
+	@command -v supabase >/dev/null 2>&1 || { echo "$(YELLOW)Supabase CLI が見つかりません。https://supabase.com/docs/guides/cli/getting-started を参照してインストールしてください。$(RESET)"; exit 1; }
+	supabase start
+
+## supabase-stop: (任意) Supabaseローカル環境を停止
+supabase-stop:
+	@command -v supabase >/dev/null 2>&1 || { echo "$(YELLOW)Supabase CLI が見つかりません。$(RESET)"; exit 1; }
+	supabase stop
+
+## supabase-reset: (任意) SupabaseローカルDBをリセット
+supabase-reset:
+	@command -v supabase >/dev/null 2>&1 || { echo "$(YELLOW)Supabase CLI が見つかりません。$(RESET)"; exit 1; }
+	supabase db reset

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 \`\`\`
 ┌─────────────────────────────────────────────────────────────────┐
 │                        Frontend (React)                         │
-│                     localhost:3001 / Hosting                    │
+│                     localhost:3000 / Hosting                    │
 ├─────────────────────────────────────────────────────────────────┤
 │                       AWS Amplify Gen2                          │
 ├──────────────┬──────────────┬──────────────────────────────────┤
@@ -74,7 +74,7 @@ cd Habits-rpg
 npm install
 
 # フロントエンド依存関係
-cd frontend && pnpm install
+cd frontend && npm install
 \`\`\`
 
 ### 開発サーバー起動
@@ -177,9 +177,11 @@ make help
 make dev          # フロントエンド開発サーバー
 make sandbox      # バックエンド Sandbox
 make deploy       # 本番デプロイ
-make lint         # Lint実行
-make format       # フォーマット
+make typecheck    # TypeScript型チェック (frontend)
+make build        # フロントエンドビルド
 make seed         # シードデータ投入 (コンソール)
+
+※ フロントエンドは `frontend/` 配下で `npm` を使用します（CI も `npm ci`）。
 \`\`\`
 
 ## 🔐 セキュリティ

--- a/docs/MIGRATION_SUPABASE.md
+++ b/docs/MIGRATION_SUPABASE.md
@@ -1,0 +1,48 @@
+---
+title: Amplify → Supabase migration notes
+---
+
+# Amplify → Supabase migration notes
+
+このリポジトリは現状 **AWS Amplify Gen2 を本番バックエンド**として運用しつつ、フロントエンド側に **Supabase クライアントの基盤**を追加して段階的に移行しています。
+
+## 現在の状態（2026-03-01）
+
+- 本番デプロイ: `main` push で GitHub Actions が Amplify をデプロイし、`amplify_outputs.json` を生成・配布します。
+- フロントエンド: `@supabase/supabase-js` を導入し、`getSupabaseClient()` を追加済み。
+- Supabase ディレクトリ (`/supabase`) は、将来的な移行用の土台として同梱されています（CI/デプロイでは使用していません）。
+
+## フロントエンドでの Supabase 設定
+
+1. `frontend/.env.example` を `frontend/.env.local` にコピー
+2. `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` を設定
+
+```bash
+cd frontend
+cp .env.example .env.local
+```
+
+Supabase クライアントは `frontend/src/lib/supabase.ts` の `getSupabaseClient()` 経由で取得します。
+
+## ローカル開発コマンド（現状の推奨）
+
+- Amplify Sandbox + フロントエンド
+
+```bash
+make sandbox  # terminal 1
+make dev      # terminal 2
+```
+
+- Supabase ローカル環境（将来/任意）
+
+```bash
+make supabase-start
+make supabase-stop
+make supabase-reset
+```
+
+## これから移行する範囲（Issue の想定）
+
+- フロントエンド data services を Supabase に置き換え
+- UserContext の id / API 形状をサービスと合わせる
+- docs / Makefile / AGENTS の記載を「現状の実態」に合わせて更新

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Habits-RPGプロジェクトのドキュメント一覧です。
 | [../README.md](../README.md) | プロジェクト概要・セットアップ |
 | [DEPLOY.md](DEPLOY.md) | CI/CDデプロイ設定・GitHub Actions |
 | [SECRETS.md](SECRETS.md) | シークレット管理・API Key |
+| [MIGRATION_SUPABASE.md](MIGRATION_SUPABASE.md) | Amplify→Supabase 移行メモ |
 
 ### アセット作成
 

--- a/docs/frontend/GUIDELINES.md
+++ b/docs/frontend/GUIDELINES.md
@@ -121,7 +121,7 @@ await userService.updateUser(userId, { displayName: 'New Name' });
 
 ```bash
 # 型チェック
-npm run typecheck
+npx tsc --noEmit
 
 # ビルド
 npm run build

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,11 +24,13 @@ npm run dev
 ## 開発コマンド
 
 ```bash
-npm run dev       # 開発サーバー起動 (localhost:3001)
+npm run dev       # 開発サーバー起動 (localhost:3000)
 npm run build     # 本番ビルド
 npm run preview   # ビルドプレビュー
 npm run lint      # Lint実行
 ```
+
+※ 開発サーバーのデフォルトは http://localhost:3000 です。
 
 ## ドキュメント
 


### PR DESCRIPTION
## Summary
- Align Makefile/AGENTS/README with the current frontend tooling (npm + port 3000)
- Add a short Supabase migration memo (current state: Amplify deploy + Supabase client foundation)

## Notes
- CI uses npm (frontend/package-lock.json) and runs typecheck/build under frontend/.
- Integration API test is network-dependent; not changed here.

Closes #36